### PR TITLE
Update normalize-css import to inline.

### DIFF
--- a/styles.less
+++ b/styles.less
@@ -8,7 +8,7 @@
 
 
 // Dependencies
-@import (css) './node_modules/normalize-css/normalize.css';
+@import (inline) './node_modules/normalize-css/normalize.css';
 
 // Base styles
 @import './ui/base/universal';


### PR DESCRIPTION
Fixes issues where a consumer of `green-frontend` receives
404 errors when trying to load `/node_modules/normalize-css/normalize.css`

![screen shot 2017-02-02 at 11 51 52 am](https://cloud.githubusercontent.com/assets/319694/22532849/3c5efdd4-e93e-11e6-8460-473e1be6167b.png)
